### PR TITLE
Added support for Session, Transaction and Aliases in Request Args

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 ======
 Export the list of databases you want to connect to as `GREMLIN_SERVERS` like so:-
 ```bash
-export GREMLIN_SERVERS="ws://server1:8182, ws://server2:8182"
+export GREMLIN_SERVERS="ws://server1:8182/gremlin, ws://server2:8182/gremlin"
 ```
 
 Import the library eg `import "github.com/go-gremlin/gremlin"`.
@@ -27,7 +27,7 @@ Parse and save your cluster of services. You only need to do this once before su
 
 Instead of using an environment variable, you can also pass the servers directly to `NewCluster()`. This is more convenient in development. For example:-
 ```go
-	if err := gremlin.NewCluster("ws://dev.local:8182", "ws://staging.local:8182"); err != nil {
+	if err := gremlin.NewCluster("ws://dev.local:8182/gremlin", "ws://staging.local:8182/gremlin"); err != nil {
 		// handle error
 	}
 ```
@@ -48,4 +48,12 @@ or unmarshal it as desired.
 You can also execute a query with bindings like this:-
 ```go
 	data, err := gremlin.Query(`g.V().has("name", userName).valueMap()`).Bindings(gremlin.Bind{"userName": "john"}).Exec()
+```
+
+You can also execute a query with Session, Transaction and Aliases 
+```go
+	aliases := make(map[string]string)
+	aliases["g"] = fmt.Sprintf("%s.g", "demo-graph")
+	session := "de131c80-84c0-417f-abdf-29ad781a7d04"  //use UUID generator
+	data, err := gremlin.Query(`g.V().has("name", userName).valueMap()`).Bindings(gremlin.Bind{"userName": "john"}).Session(session).ManageTransaction(true).SetProcessor("session").Aliases(aliases).Exec()
 ```

--- a/request.go
+++ b/request.go
@@ -12,13 +12,15 @@ type Request struct {
 }
 
 type RequestArgs struct {
-	Gremlin    string `json:"gremlin,omitempty"`
-	Session    string `json:"session,omitempty"`
-	Bindings   Bind   `json:"bindings,omitempty"`
-	Language   string `json:"language,omitempty"`
-	Rebindings Bind   `json:"rebindings,omitempty"`
-	Sasl       []byte `json:"sasl,omitempty"`
-	BatchSize  int    `json:"batchSize,omitempty"`
+	Gremlin           string            `json:"gremlin,omitempty"`
+	Session           string            `json:"session,omitempty"`
+	Bindings          Bind              `json:"bindings,omitempty"`
+	Language          string            `json:"language,omitempty"`
+	Rebindings        Bind              `json:"rebindings,omitempty"`
+	Sasl              []byte            `json:"sasl,omitempty"`
+	BatchSize         int               `json:"batchSize,omitempty"`
+	ManageTransaction bool              `json:"manageTransaction,omitempty"`
+	Aliases           map[string]string `json:"aliases,omitempty"`
 }
 
 type Bind map[string]interface{}
@@ -39,5 +41,25 @@ func Query(query string) *Request {
 
 func (req *Request) Bindings(bindings Bind) *Request {
 	req.Args.Bindings = bindings
+	return req
+}
+
+func (req *Request) ManageTransaction(flag bool) *Request {
+	req.Args.ManageTransaction = flag
+	return req
+}
+
+func (req *Request) Aliases(aliases map[string]string) *Request {
+	req.Args.Aliases = aliases
+	return req
+}
+
+func (req *Request) Session(session string) *Request {
+	req.Args.Session = session
+	return req
+}
+
+func (req *Request) SetProcessor(processor string) *Request {
+	req.Processor = processor
 	return req
 }


### PR DESCRIPTION
Based on the specification http://tinkerpop.apache.org/docs/3.1.0-incubating/#_developing_a_driver extend the Request struct to support Transaction, Aliases, Session and fixed documentation for better usability.