### PR TITLE
[wip] add concurrent WS client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,283 @@
+package gremlin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	maxMessages    = 1024
+	maxMessageSize = 0
+	writeWait      = 5 * time.Second
+	pongTimeout    = 5 * time.Second
+)
+
+var (
+	ErrConnectionClosed = errors.New("Connection closed")
+	ErrUnknownError     = errors.New("An unknown error occured")
+)
+
+// ClientRequest describes the message to be sent
+// to the client for issuing a request
+type clientRequest struct {
+	request  *Request
+	dispatch chan clientResponse
+}
+
+// ClientResponse describe the message returned by the
+// client after a request is made
+type clientResponse struct {
+	response Response
+	err      error
+}
+
+// Client describe a connection to the gremlin server
+type Client struct {
+	endpoint            string
+	dialer              websocket.Dialer
+	conn                *websocket.Conn
+	dispatch            map[string]chan clientResponse
+	send                chan clientRequest
+	read                chan []byte
+	quit                chan error
+	connected           atomic.Value
+	running             atomic.Value
+	connectedEvent      chan bool
+	disconnectedEvent   chan bool
+	pingTicker          *time.Ticker
+	connectedHandler    func()
+	disconnectedHandler func(error)
+}
+
+// NewClient creates a new gremlin client
+func NewClient(serverURL string) *Client {
+	d := websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 3 * time.Second,
+		ReadBufferSize:   8192,
+		WriteBufferSize:  32768,
+	}
+	c := &Client{
+		endpoint:            serverURL,
+		dialer:              d,
+		dispatch:            make(map[string]chan clientResponse),
+		send:                make(chan clientRequest, maxMessages),
+		read:                make(chan []byte, maxMessages),
+		quit:                make(chan error, 2),
+		connectedEvent:      make(chan bool, 1),
+		disconnectedEvent:   make(chan bool, 1),
+		connectedHandler:    func() { return },
+		disconnectedHandler: func(err error) { return },
+	}
+	c.connected.Store(false)
+	c.running.Store(true)
+	return c
+}
+
+// AddConnectedHandler runs handler when client is connected
+func (c *Client) AddConnectedHandler(h func()) {
+	c.connectedHandler = h
+}
+
+// AddDisconnectedHandler runs handler when connection is closed
+func (c *Client) AddDisconnectedHandler(h func(error)) {
+	c.disconnectedHandler = h
+}
+
+func (c *Client) connect() (err error) {
+	c.conn, _, err = c.dialer.Dial(c.endpoint, http.Header{})
+	if err != nil {
+		return
+	}
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(100 * time.Second))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongTimeout))
+		return nil
+	})
+
+	c.connected.Store(true)
+	c.connectedEvent <- true
+	c.pingTicker = time.NewTicker(pongTimeout * 8 / 10)
+
+	defer c.connected.Store(false)
+	go c.connectedHandler()
+	return c.run()
+}
+
+func (c *Client) run() error {
+	go func() {
+		for c.running.Load() == true {
+			_, m, err := c.conn.ReadMessage()
+			if err != nil {
+				if c.running.Load() == true {
+					c.quit <- err
+				}
+				break
+			}
+			c.read <- m
+		}
+	}()
+
+	for {
+		select {
+		case err := <-c.quit:
+			// Send errors to clients waiting for a response
+			// before closing
+			for id, dispatch := range c.dispatch {
+				dispatch <- clientResponse{err: ErrConnectionClosed}
+				close(dispatch)
+				delete(c.dispatch, id)
+			}
+			return err
+		case cr := <-c.send:
+			c.dispatch[cr.request.RequestId] = cr.dispatch
+			err := c.sendRequest(cr.request)
+			if err != nil {
+				cr.dispatch <- clientResponse{err: err}
+			}
+		case m := <-c.read:
+			c.dispatchMsg(m)
+		case <-c.pingTicker.C:
+			c.sendPing()
+		}
+	}
+}
+
+func (c *Client) sendPing() {
+	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err := c.conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (c *Client) dispatchMsg(msg []byte) {
+	var res Response
+	err := json.Unmarshal(msg, &res)
+	if ch, ok := c.dispatch[res.RequestId]; ok {
+		if err != nil {
+			ch <- clientResponse{err: err}
+		} else {
+			ch <- clientResponse{response: res}
+		}
+		if res.Status.Code != StatusPartialContent {
+			close(c.dispatch[res.RequestId])
+			delete(c.dispatch, res.RequestId)
+		}
+	}
+}
+
+func (c *Client) sendRequest(r *Request) (err error) {
+	// Prepare the Data
+	message, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+	// Prepare the request message
+	var requestMessage []byte
+	mimeType := []byte("application/json")
+	mimeTypeLen := byte(len(mimeType))
+	requestMessage = append(requestMessage, mimeTypeLen)
+	requestMessage = append(requestMessage, mimeType...)
+	requestMessage = append(requestMessage, message...)
+
+	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err := c.conn.WriteMessage(websocket.BinaryMessage, requestMessage); err != nil {
+		fmt.Println(err)
+	}
+	return
+}
+
+// ConnectAsync connects to the server - and reconnect if necessary
+func (c *Client) ConnectAsync() {
+	go func() {
+		for c.running.Load() == true {
+			err := c.connect()
+			c.connectedEvent = make(chan bool, 1)
+			c.disconnectedHandler(err)
+			time.Sleep(1 * time.Second)
+		}
+		c.disconnectedEvent <- true
+	}()
+}
+
+// Connect connects to the server and block until connection is successful
+func (c *Client) Connect() {
+	c.ConnectAsync()
+	<-c.connectedEvent
+}
+
+// Disconnect the client without waiting for termination
+func (c *Client) Disconnect() {
+	c.running.Store(false)
+	if c.connected.Load() == true {
+		c.quit <- nil
+		c.conn.Close()
+		close(c.send)
+		close(c.read)
+	}
+	<-c.disconnectedEvent
+}
+
+// IsConnected returns true if the client is connected
+func (c *Client) IsConnected() bool {
+	return c.connected.Load() == true
+}
+
+// Send sends a request to the gremlin server and wait for results
+func (c *Client) Send(r *Request) (data []byte, err error) {
+	if !c.IsConnected() {
+		err = errors.New("Not connected")
+		return
+	}
+	ch := make(chan clientResponse)
+	c.send <- clientRequest{request: r, dispatch: ch}
+	inBatchMode := false
+	var dataItems []json.RawMessage
+	for clientRes := range ch {
+		if clientRes.err != nil {
+			err = clientRes.err
+			return
+		}
+		res := clientRes.response
+		var items []json.RawMessage
+
+		switch clientRes.response.Status.Code {
+		case StatusNoContent:
+			return
+
+		case StatusPartialContent:
+			inBatchMode = true
+			if err = json.Unmarshal(res.Result.Data, &items); err != nil {
+				return
+			}
+			dataItems = append(dataItems, items...)
+
+		case StatusSuccess:
+			if inBatchMode {
+				if err = json.Unmarshal(res.Result.Data, &items); err != nil {
+					return
+				}
+				dataItems = append(dataItems, items...)
+				data, err = json.Marshal(dataItems)
+			} else {
+				data = res.Result.Data
+			}
+
+		default:
+			if msg, exists := ErrorMsg[res.Status.Code]; exists {
+				err = errors.New(msg)
+			} else {
+				err = ErrUnknownError
+			}
+		}
+	}
+	return
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,257 @@
+package gremlin
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type testServer struct {
+	Done      chan struct{}
+	Responses [][]Response
+	srv       *http.Server
+}
+
+var upgrader = websocket.Upgrader{} // use default options
+
+func newTestServer() *testServer {
+	return &testServer{
+		Done: make(chan struct{}),
+		srv:  &http.Server{Addr: ":8080"},
+	}
+}
+
+func (t *testServer) Start() {
+	http.HandleFunc("/gremlin", t.gremlin)
+	err := t.srv.ListenAndServe()
+	if err != nil {
+		log.Println("ListenAndServe: ", err)
+	}
+}
+
+func (t *testServer) Stop() {
+	if err := t.srv.Shutdown(nil); err != nil {
+		log.Fatal("Shutdown: ", err)
+	}
+}
+
+func (t *testServer) gremlin(w http.ResponseWriter, r *http.Request) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Print("upgrade:", err)
+		return
+	}
+	defer c.Close()
+	for {
+		_, _, err := c.ReadMessage()
+		if err != nil {
+			log.Println("read:", err)
+			break
+		}
+		resps := t.Responses[0]
+		for _, r := range resps {
+			//fmt.Printf("write %v %v %v\n", r.RequestId, r.Status.Code, string(r.Result.Data))
+			msg, err := json.Marshal(r)
+			if err != nil {
+				log.Println("write:", err)
+				return
+			}
+			c.WriteMessage(websocket.BinaryMessage, msg)
+		}
+		t.Responses = t.Responses[1:]
+	}
+}
+
+var (
+	s *testServer
+	c *Client
+)
+
+func init() {
+	s = newTestServer()
+	go s.Start()
+	c = NewClient("ws://localhost:8080/gremlin")
+	c.Connect()
+}
+
+func TestSingleResponse(t *testing.T) {
+	reqID := uuid.NewV4().String()
+
+	s.Responses = [][]Response{
+		[]Response{
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: 200,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[1, 2, 3]"),
+				},
+			},
+		},
+	}
+
+	q := Query("")
+	q.RequestId = reqID
+	data, _ := c.Send(q)
+
+	assert.Equal(t, "[1,2,3]", string(data), "Response should contain data from a single response")
+}
+
+func TestEmptyResponse(t *testing.T) {
+	reqID := uuid.NewV4().String()
+
+	s.Responses = [][]Response{
+		[]Response{
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: 204,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[1, 2, 3]"),
+				},
+			},
+		},
+	}
+
+	q := Query("")
+	q.RequestId = reqID
+	data, _ := c.Send(q)
+
+	assert.Equal(t, "", string(data), "Response should not contain any data")
+}
+
+func TestPartialResponse(t *testing.T) {
+	reqID := uuid.NewV4().String()
+
+	s.Responses = [][]Response{
+		[]Response{
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: 206,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[1, 2]"),
+				},
+			},
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: 206,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[3, 4]"),
+				},
+			},
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: 200,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[5, 6]"),
+				},
+			},
+		},
+	}
+
+	q := Query("")
+	q.RequestId = reqID
+	data, _ := c.Send(q)
+
+	assert.Equal(t, "[1,2,3,4,5,6]", string(data), "Response should contain aggregated data from responses")
+}
+
+func TestConcurrentRequest(t *testing.T) {
+	reqID1 := uuid.NewV4().String()
+	reqID2 := uuid.NewV4().String()
+
+	s.Responses = [][]Response{
+		[]Response{
+			Response{
+				RequestId: reqID1,
+				Status: &ResponseStatus{
+					Code: 206,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[1, 2]"),
+				},
+			},
+			Response{
+				RequestId: reqID1,
+				Status: &ResponseStatus{
+					Code: 200,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[5, 6]"),
+				},
+			},
+		},
+		[]Response{
+			Response{
+				RequestId: reqID2,
+				Status: &ResponseStatus{
+					Code: 200,
+				},
+				Result: &ResponseResult{
+					Data: json.RawMessage("[3, 4]"),
+				},
+			},
+		},
+	}
+
+	q1 := Query("")
+	q1.RequestId = reqID1
+	q2 := Query("")
+	q2.RequestId = reqID2
+
+	rs := make(chan string, 2)
+
+	go func() {
+		data1, _ := c.Send(q1)
+		rs <- string(data1)
+	}()
+	go func() {
+		data2, _ := c.Send(q2)
+		rs <- string(data2)
+	}()
+
+	r1 := <-rs
+	if r1 == "[1,2,5,6]" {
+		r2 := <-rs
+		assert.Equal(t, "[3,4]", string(r2), "Response should contain reqID2 results")
+	} else {
+		r2 := <-rs
+		assert.Equal(t, "[1,2,5,6]", string(r2), "Response should contain reqID1 results")
+	}
+
+}
+
+func TestError(t *testing.T) {
+	reqID := uuid.NewV4().String()
+
+	s.Responses = [][]Response{
+		[]Response{
+			Response{
+				RequestId: reqID,
+				Status: &ResponseStatus{
+					Code: StatusServerError,
+				},
+			},
+		},
+	}
+
+	q := Query("")
+	q.RequestId = reqID
+	_, err := c.Send(q)
+
+	assert.Equal(t, ErrorMsg[StatusServerError], err.Error(), "Should get server error")
+
+}


### PR DESCRIPTION
This allows to create one client that will be used to handle subsequent
requests and not creating a WS connection for each request.

Concurrent usage of the client should be safe.

Current usage is:

```go
    c := gremlin.NewClient("ws://localhost:8182/gremlin")
    c.Connect()

    time.Sleep(1 * time.Second)

    _, err := c.Send(gremlin.Query("g.V().id()"))
    if err != nil {
        fmt.Println(err)
    }

    _, err = c.Send(gremlin.Query("g.V("))
    if err != nil {
        fmt.Println(err)
    }

    c.Disconnect()
```