### PR TITLE
Implement authntication

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ You can also execute a query with Session, Transaction and Aliases
 	session := "de131c80-84c0-417f-abdf-29ad781a7d04"  //use UUID generator
 	data, err := gremlin.Query(`g.V().has("name", userName).valueMap()`).Bindings(gremlin.Bind{"userName": "john"}).Session(session).ManageTransaction(true).SetProcessor("session").Aliases(aliases).Exec()
 ```
+
+Authentication
+===
+For authentication, you can set environment variables `GREMLIN_USER` and `GREMLIN_PASS` and create a `Client`:
+
+```go
+	client, err := gremlin.NewClient("ws://remote.example.com:443/gremlin")
+	data, err = client.ExecQuery(`g.V()`)
+	if err != nil {
+		panic(err)
+	}
+	doStuffWith(data)
+```

--- a/README.md
+++ b/README.md
@@ -62,10 +62,22 @@ You can also execute a query with Session, Transaction and Aliases
 
 Authentication
 ===
-For authentication, you can set environment variables `GREMLIN_USER` and `GREMLIN_PASS` and create a `Client`:
+For authentication, you can set environment variables `GREMLIN_USER` and `GREMLIN_PASS` and create a `Client`, passing functional parameter `OptAuthEnv`
 
 ```go
-	client, err := gremlin.NewClient("ws://remote.example.com:443/gremlin")
+	auth := gremlin.OptAuthEnv()
+	client, err := gremlin.NewClient("ws://remote.example.com:443/gremlin", auth)
+	data, err = client.ExecQuery(`g.V()`)
+	if err != nil {
+		panic(err)
+	}
+	doStuffWith(data)
+```
+
+If you don't like environment variables you can authenticate passing username and password string in the following way:
+```go
+	auth := gremlin.OptAuthUserPass("myusername", "mypass")
+	client, err := gremlin.NewClient("ws://remote.example.com:443/gremlin", auth)
 	data, err = client.ExecQuery(`g.V()`)
 	if err != nil {
 		panic(err)

--- a/connection.go
+++ b/connection.go
@@ -24,13 +24,8 @@ func NewClient(urlStr string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.DialTimeout("tcp", r.Host, 1*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	// TODO rewrite with dialer since NewClient is deprecated
-	//	d := websocket.Dialer{}
-	ws, _, err := websocket.NewClient(conn, r, http.Header{}, 0, 0)
+	dialer := websocket.Dialer{}
+	ws, _, err := dialer.Dial(urlStr, http.Header{})
 	if err != nil {
 		return nil, err
 	}

--- a/request.go
+++ b/request.go
@@ -2,7 +2,7 @@ package gremlin
 
 import (
 	"encoding/json"
-	"fmt"
+	_ "fmt"
 	"github.com/satori/go.uuid"
 )
 
@@ -25,34 +25,33 @@ type RequestArgs struct {
 	Aliases           map[string]string `json:"aliases,omitempty"`
 }
 
-type GraphsonSerializer struct {
-}
-
-type StyledReq struct {
-	RequestId interface{}  `json:"requestId"`
+// Formats the requests in the appropriate way
+type FormattedReq struct {
 	Op        string       `json:"op"`
-	Processor string       `json:"processor"`
+	RequestId interface{}  `json:"requestId"`
 	Args      *RequestArgs `json:"args"`
+	Processor string       `json:"processor"`
 }
 
-func (s StyledReq) MarshalJSON() ([]byte, error) {
-	msg, err := json.Marshal(s)
+func GraphSONSerializer(req *Request) ([]byte, error) {
+	form := NewFormattedReq(req)
+	msg, err := json.Marshal(form)
 	if err != nil {
 		return nil, err
 	}
-	var mimeLen = []byte{0x21}
 	mimeType := []byte("application/vnd.gremlin-v2.0+json")
-	fmt.Println("hello")
+	var mimeLen = []byte{0x21}
 	res := append(mimeLen, mimeType...)
 	res = append(res, msg...)
 	return res, nil
 
 }
 
-func NewStyledReq(req *Request) StyledReq {
+func NewFormattedReq(req *Request) FormattedReq {
 	rId := map[string]string{"@type": "g:UUID", "@value": req.RequestId}
-	return StyledReq{RequestId: rId,
-		Processor: req.Processor, Op: req.Op, Args: req.Args}
+	sr := FormattedReq{RequestId: rId, Processor: req.Processor, Op: req.Op, Args: req.Args}
+
+	return sr
 }
 
 type Bind map[string]interface{}

--- a/request.go
+++ b/request.go
@@ -1,6 +1,8 @@
 package gremlin
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/satori/go.uuid"
 )
 
@@ -17,10 +19,40 @@ type RequestArgs struct {
 	Bindings          Bind              `json:"bindings,omitempty"`
 	Language          string            `json:"language,omitempty"`
 	Rebindings        Bind              `json:"rebindings,omitempty"`
-	Sasl              []byte            `json:"sasl,omitempty"`
+	Sasl              string            `json:"sasl,omitempty"`
 	BatchSize         int               `json:"batchSize,omitempty"`
 	ManageTransaction bool              `json:"manageTransaction,omitempty"`
 	Aliases           map[string]string `json:"aliases,omitempty"`
+}
+
+type GraphsonSerializer struct {
+}
+
+type StyledReq struct {
+	RequestId interface{}  `json:"requestId"`
+	Op        string       `json:"op"`
+	Processor string       `json:"processor"`
+	Args      *RequestArgs `json:"args"`
+}
+
+func (s StyledReq) MarshalJSON() ([]byte, error) {
+	msg, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+	var mimeLen = []byte{0x21}
+	mimeType := []byte("application/vnd.gremlin-v2.0+json")
+	fmt.Println("hello")
+	res := append(mimeLen, mimeType...)
+	res = append(res, msg...)
+	return res, nil
+
+}
+
+func NewStyledReq(req *Request) StyledReq {
+	rId := map[string]string{"@type": "g:UUID", "@value": req.RequestId}
+	return StyledReq{RequestId: rId,
+		Processor: req.Processor, Op: req.Op, Args: req.Args}
 }
 
 type Bind map[string]interface{}


### PR DESCRIPTION
Implements SASL authentication as specified [here](https://tinkerpop.apache.org/docs/3.0.2-incubating/#_developing_a_driver). It creates a `Client` object that reuses connections and authenticate.
Closes #5 