### PR TITLE
Change Titan with JanusGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gremlin Server Client for Go
 
-This library will allow you to connect to any graph database that supports TinkerPop3 using `Go`. This includes databases like Titan and Neo4J. TinkerPop3 uses Gremlin Server to communicate with clients using either WebSockets or REST API. This library talks to Gremlin Server using WebSockets.
+This library will allow you to connect to any graph database that supports TinkerPop3 using `Go`. This includes databases like JanusGraph and Neo4J. TinkerPop3 uses Gremlin Server to communicate with clients using either WebSockets or REST API. This library talks to Gremlin Server using WebSockets.
 
 *NB*: Please note that this driver is [currently looking for maintainers](https://github.com/go-gremlin/gremlin/issues/8).
 


### PR DESCRIPTION
Titan is outdated and unmaintained. JanusGraph is its direct successor.